### PR TITLE
Update RPM build instructions

### DIFF
--- a/src/wiki/development/build-instructions.md
+++ b/src/wiki/development/build-instructions.md
@@ -96,16 +96,16 @@ rpmdev-setuptree
 # get the rpm spec file from the prismlauncher-rpm repo
 git clone https://pagure.io/prismlauncher-rpm.git
 cd prismlauncher-rpm
-# the package builds with Qt6 by default, but can build with Qt5 by using this
-sed -i 's/%bcond_without/%bcond_with/' prismlauncher.spec
 # install build dependencies
 sudo dnf builddep prismlauncher.spec
+sudo dnf builddep -D "_without_qt6 1" prismlauncher.spec # if you want to use Qt 5 instead of Qt 6
 # download build sources
 spectool -g -R prismlauncher.spec
 # move patch to rpmbuild sources directory
 cp change-jars-path.patch ~/rpmbuild/SOURCES 
 # now build!
 rpmbuild -bb prismlauncher.spec
+rpmbuild -bb --without qt6 prismlauncher.spec # if you want to use Qt 5 instead of Qt 6
 ```
 
 The path to the .rpm packages will be printed once the build is complete.

--- a/src/wiki/development/build-instructions.md
+++ b/src/wiki/development/build-instructions.md
@@ -94,11 +94,14 @@ cd ~
 # setup your ~/rpmbuild directory, required for rpmbuild to work.
 rpmdev-setuptree
 # get the rpm spec file from the prismlauncher-misc repo
-wget https://copr-dist-git.fedorainfracloud.org/cgit/sentry/prismlauncher/prismlauncher.git/plain/prismlauncher.spec
+git clone https://pagure.io/prismlauncher-rpm.git
+cd prismlauncher-rpm
 # install build dependencies
 sudo dnf builddep prismlauncher.spec
 # download build sources
 spectool -g -R prismlauncher.spec
+# move patch to rpmbuild sources directory
+cp change-jars-path.patch ~/rpmbuild/SOURCES 
 # now build!
 rpmbuild -bb prismlauncher.spec
 ```

--- a/src/wiki/development/build-instructions.md
+++ b/src/wiki/development/build-instructions.md
@@ -93,9 +93,11 @@ You don't need to clone the repo for this; the spec file handles that.
 cd ~
 # setup your ~/rpmbuild directory, required for rpmbuild to work.
 rpmdev-setuptree
-# get the rpm spec file from the prismlauncher-misc repo
+# get the rpm spec file from the prismlauncher-rpm repo
 git clone https://pagure.io/prismlauncher-rpm.git
 cd prismlauncher-rpm
+# the package builds with Qt6 by default, but can build with Qt5 by using this
+sed -i 's/%bcond_without/%bcond_with/' prismlauncher.spec
 # install build dependencies
 sudo dnf builddep prismlauncher.spec
 # download build sources


### PR DESCRIPTION
the previous link led to a non-existent repository, so i changed it to the repo [copr](https://copr.fedorainfracloud.org/coprs/g3tchoo/prismlauncher/) builds from (source is [here](https://pagure.io/prismlauncher-rpm))

since my new spec file allows for the option to build with either qt6 or qt5, i also added a sed command that would change it from the default qt6 :p