### PR TITLE
Use `--no-quarantine` for `brew` in mac install directions

### DIFF
--- a/src/download/mac.md
+++ b/src/download/mac.md
@@ -31,7 +31,7 @@ eleventyNavigation:
 #### Installation instructions
 
 ```bash
-brew install --cask prismlauncher
+brew install --cask --no-quarantine prismlauncher
 ```
 
 <!--


### PR DESCRIPTION
Using the `--no-quarantine` flag when installing using Homebrew makes it so you don't have to open system preferences and manually allow the unsigned app, brew does it all for you. (yes this is a stupid pr)

See: https://houtianze.github.io/brew/mac/2020/02/18/brew-no-quarantine.html

Signed-off-by: Pauline <git@ethanlibs.co>